### PR TITLE
Fix AttributeError in Cursor.__exit__

### DIFF
--- a/dejavu/database_handler/mysql_database.py
+++ b/dejavu/database_handler/mysql_database.py
@@ -191,7 +191,7 @@ class Cursor(object):
     def __exit__(self, extype, exvalue, traceback):
         # if we had a MySQL related error we try to rollback the cursor.
         if extype is DatabaseError:
-            self.cursor.rollback()
+            self.conn.rollback()
 
         self.cursor.close()
         self.conn.commit()


### PR DESCRIPTION
Fix <AttributeError: 'CMySQLCursor' object has no attribute 'rollback'>. 
`rollback()` should be attribute of MySQLConnection